### PR TITLE
feat: add deploy playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Drupal Deploy with Ansble Playbooks
+
+This repos contains self-contained playbooks to be used with [AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/what-is-systems-manager.html) to deploy new versions of a Drupal project.
+
+## Playbook: deploy-git.yml
+
+This playbook handles the deploy of git-based projects, which as of Feb 2023 is the current standard of NyMedia/Frontkom deploys.
+It can handle both tags and branches using git checkout.
+
+### Playbook's variables
+
+| Name | Description | Default |
+--------------------------------
+| `repo_root` | Git repo root, absolute path | "/var/www/html" |
+| `drupal_root` | Drupal root dir, absolute path | repo_root + "/drupal" |
+| `git_ref` | Version to deploy, must be a valid git ref (tag ro branch) | "master" |
+| `sql_dump_timeout` | Timeout _(in seconds)_ for the drush sql dump | 60 |
+| `git_repo_url` | Git repository URL, if not provided will be fetched from `repo_root` | _Undefined_ |

--- a/deploy-git.yml
+++ b/deploy-git.yml
@@ -1,0 +1,79 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+
+  vars:
+    repo_root: "{{ deploy_repo_root | default('/var/www/html') }}"
+    drupal_root: "{{ deploy_drupal | default([repo_root, '/drupal'] | join) }}"
+    git_ref: "{{ deploy_git_ref | default('master') }}"
+    sql_dump_timeout: 60
+
+  tasks:
+    - name: Git - Get current remote URL
+      block:
+        - command:
+            cmd: git remote get-url origin
+            cwd: "{{ repo_root }}"
+          register: git_remote
+        - set_facts:
+            git_repo_url: "{{ git_remote.stdout }}"
+      when: (git_repo_url is undefined) or (git_repo_url == "")
+
+    - name: Git - Ensure no uncommitted changes
+      command:
+        cmd: git status --porcelain --untracked-files=no
+        cwd: "{{ repo_root }}"
+      register: git_status
+      failed_when: >
+        (git_status.rc != 0) or
+        (git_status.stdout_lines | length > 0)
+
+    - name: Git - Fetch
+      command:
+        cmd: git fetch --tags --prune --prune-tags
+        cwd: "{{ repo_root }}"
+      register: git_fetch
+
+    - name: Git - Check for new version
+      ansible.builtin.git:
+        repo: "{{ git_repo_url }}"
+        dest: "{{ repo_root }}"
+        version: "{{ git_ref }}"
+        # Only check for changes
+        update: false
+      register: git_check_update
+
+    # We check if there are any changes before and after the
+    - block:
+        - name: End play if commit did not change
+          debug:
+            msg: "No changes. Commit was: {{ git_check_update.before }}"
+        - meta: end_play
+      when: git_check_update.before = git_check_update.after
+
+    - name: Drush - Run backup
+      command:
+        cmd: drush sql:dump --no-ansi --no-interaction
+        cwd: "{{ drupal_root }}"
+      register: drush_sqldump
+      # We have some trouble with the drush sql:dump command timing out. As
+      # workaround we try to run it 3 times with a pre-defined timeout before
+      # giving up.
+      # @see: https://github.com/nymedia/internal-operations-support/issues/35
+      timeout: "{{ sql_dump_timeout }}"
+      retries: 3
+      # Example of output: "[success] Database dump saved to ..."
+      until: drush_sqldump.stdout.find("[success]") != -1
+
+    - name: Git - Checkout new version
+      ansible.builtin.git:
+        repo: "{{ git_repo_url }}"
+        dest: "{{ repo_root }}"
+        version: "{{ git_ref }}"
+        update: true
+      register: git_checkout
+
+    - name: Composer build
+      command:
+        cmd: composer build
+        cwd: "{{ repo_root }}"


### PR DESCRIPTION
## What is the objective of this PR
<!-- Are there any links to specifications, references from correspondances or similar that is relevant? Please add them here. -->

This adds a playbook to handle deployments using git-based approach and AWS' Systems Manager.

Specifically the playbook will be used with the [*Automation* feature](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation.html) of AWS SSM.


## List steps taken for own manual testing
<!-- If your task is to set a field upon updating a node, and you just altered the code so that it looks correct, please also make sure you try to actually save a node. Maybe you want to save a couple of different node types even. -->

N/A

## Instructions for testing
<!-- One such recipe would be to list the steps to deploy this branch locally, and the steps needed to test that the PR does what it is supposed to. -->

N/A

## Additional info
<!-- Put some additional info here that doesn't fit any other places, for example list manual deployment steps -->

- Article: [Keeping Ansible effortless with AWS Systems Manager](https://aws.amazon.com/blogs/mt/keeping-ansible-effortless-with-aws-systems-manager/)
- Article: [Running Ansible playbook using AWS Systems Manager](https://www.infinitypp.com/ansible/aws-systems-manager-playbook/)
