### PR TITLE
feat(CI): add workflow to add playbooks to s3

### DIFF
--- a/.github/workflows/upload-to-aws.yml
+++ b/.github/workflows/upload-to-aws.yml
@@ -1,0 +1,31 @@
+name: Deploy to S3
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE}}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Extract git tag name
+        id: get-git-tag
+        run: >-
+          echo "tag_name=$(echo ${GITHUB_REF} | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+
+      - name: Copy playbooks to S3
+        run: |
+          aws s3 cp *.yml s3://${{ secrets.AWS_BUCKET_NAME }}/${{ steps.get-git-tag.outputs.tag_name }}/

--- a/.github/workflows/upload-to-aws.yml
+++ b/.github/workflows/upload-to-aws.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE}}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/automation/GithubActionsAnsibleDrupalDeploy
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Extract git tag name

--- a/.github/workflows/upload-to-aws.yml
+++ b/.github/workflows/upload-to-aws.yml
@@ -18,8 +18,19 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/automation/GithubActionsAnsibleDrupalDeploy
           aws-region: ${{ secrets.AWS_REGION }}
+          # @see https://github.com/nymedia/infra-aws/pull/17
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/automation/GithubActionsAnsibleDrupalDeploy
+
+      - name: Assume execution role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
+          role-duration-seconds: 300
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_AUTOMATION_ACCOUNT_ID }}:role/automation/TBD
 
       - name: Extract git tag name
         id: get-git-tag


### PR DESCRIPTION
## What is the objective of this PR
<!-- Are there any links to specifications, references from correspondances or similar that is relevant? Please add them here. -->

This adds a workflow that enabled uploading the Ansible workflows to S3, so they can be used on AWS.

## Additional info
<!-- Put some additional info here that doesn't fit any other places, for example list manual deployment steps -->

This uses [the OIDC integration](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) to access AWS instead of traditional users and secrets.

AWS Role added here: https://github.com/nymedia/infra-aws/pull/17
and: https://github.com/nymedia/infra-aws/pull/18