### PR TITLE
fix: include the ".docker" directory in the build context

### DIFF
--- a/defaults/container/drupal-php.dockerignore
+++ b/defaults/container/drupal-php.dockerignore
@@ -1,6 +1,7 @@
 .git/
 .ddev/
 .docker/
+4
 .github/
 .idea/
 .travis/

--- a/defaults/container/nginx.dockerignore
+++ b/defaults/container/nginx.dockerignore
@@ -1,5 +1,4 @@
 .git/
-.docker/
 .github/
 .travis/
 


### PR DESCRIPTION
# What

- Remove the `.docker/` from dockerignore file

# Why

- This directory does contain the build Dockerfiles when they are customized.